### PR TITLE
Explicitly choose port 5432

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ENV PATH="/opt/pgedge/pg${PGV}/bin:/opt/pgedge:${PATH}"
 # Install pgEdge Postgres binaries and pgvector
 ARG PGEDGE_INSTALL_URL="https://pgedge-download.s3.amazonaws.com/REPO/install.py"
 RUN python3 -c "$(curl -fsSL ${PGEDGE_INSTALL_URL})"
-RUN ./pgedge/ctl install pgedge -U ${INIT_USERNAME} -d ${INIT_DATABASE} -P ${INIT_PASSWORD} --pg ${PGV} \
+RUN ./pgedge/ctl install pgedge -U ${INIT_USERNAME} -d ${INIT_DATABASE} -P ${INIT_PASSWORD} --pg ${PGV} -p 5432 \
     && ./pgedge/ctl um install vector \
     && pg_ctl stop
 


### PR DESCRIPTION
This fixes an issue where port 5433 was mistakenly chosen after having built the images using `docker buildx` multi-platform images. Potentially port 5432 was detected as "in use" for some reason in that situation.

```
## PLATFORM: linux/arm64
➜  ~ docker run -it --rm --platform linux/arm64 pgedge/pgedge:dd1ddcc | grep port
2024-01-31 14:03:01 UTC [10]: [2-1] user=,db=,app=,client= LOG:  listening on IPv4 address "0.0.0.0", port 5432
2024-01-31 14:03:01 UTC [10]: [3-1] user=,db=,app=,client= LOG:  listening on IPv6 address "::", port 5432

## PLATFORM: linux/amd64
➜  ~ docker run -it --rm --platform linux/amd64 pgedge/pgedge:dd1ddcc | grep port
Unable to find image 'pgedge/pgedge:dd1ddcc' locally
dd1ddcc: Pulling from pgedge/pgedge
Digest: sha256:c39d1644b53a1b7d575f24f493033ebb47de388963982f0ef402b04e192f6daa
Status: Downloaded newer image for pgedge/pgedge:dd1ddcc
2024-01-31 14:03:09 UTC [30]: [2-1] user=,db=,app=,client= LOG:  listening on IPv4 address "0.0.0.0", port 5433
2024-01-31 14:03:09 UTC [30]: [3-1] user=,db=,app=,client= LOG:  listening on IPv6 address "::", port 5433
```
