### PR TITLE
Limit parallelism in buildx builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,22 @@ GIT_REVISION=$(shell git rev-parse --short HEAD)
 
 IMAGE_NAME=pgedge/pgedge
 
-DOCKER_BUILDX=docker buildx build --platform linux/amd64,linux/arm64
+BUILDER_NAME=pgedge-builder
+
+DOCKER_BUILDX=docker buildx build --builder $(BUILDER_NAME) --platform linux/amd64,linux/arm64
 
 .PHONY: build
 build:
 	docker build -t $(IMAGE_NAME) -t $(IMAGE_NAME):$(GIT_REVISION) .
+
+.PHONY: buildx-init
+buildx-init:
+	docker buildx create \
+		--use \
+		--name $(BUILDER_NAME) \
+		--platform linux/arm64,linux/amd64 \
+		--config ./buildkitd.toml
+	docker buildx inspect --bootstrap
 
 .PHONY: buildx
 buildx:

--- a/buildkitd.toml
+++ b/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 1


### PR DESCRIPTION
Concurrent multi-arch builds appear to use the same network stack, which makes port 5432 unavailable in one of the builds.

This updated configuration limits buildx to build one at a time.

https://docs.docker.com/build/buildkit/configure/#max-parallelism

