### PR TITLE
upgrade to latest pg minor releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN useradd -u ${PGEDGE_USER_ID} -m pgedge -s /bin/bash && \
 # executable. Installing it ourselves via pip is a workaround. It's important
 # that we install the exact same version of ydiff as what's specified in the
 # CLI's requirements.txt.
-RUN su - pgedge -c "pip3 install --user psycopg[binary]==3.2.3 ydiff==1.3"
+RUN su - pgedge -c "pip3 install --user psycopg[binary]==3.2.7 ydiff==1.3"
 
 # Create the suggested data directory for Postgres in advance. Because Postgres
 # is picky about data directory ownership and permissions, the PGDATA directory
@@ -70,11 +70,13 @@ ENV INIT_PASSWORD=${INIT_PASSWORD}
 
 # Postgres verion to install
 ARG PGV="16"
-ARG PGEDGE_INSTALL_URL="https://pgedge-download.s3.amazonaws.com/REPO/install.py"
+ARG REPO="https://pgedge-download.s3.amazonaws.com/REPO"
+ARG PGEDGE_INSTALL_URL="${REPO}/install.py"
 ARG SPOCK_VERSION="4.0.10"
 
 # Install pgEdge Postgres binaries and pgvector
 ENV PGV=${PGV}
+ENV REPO=${REPO}
 ENV PGDATA="/opt/pgedge/data/pg${PGV}"
 ENV PATH="/opt/pgedge/pg${PGV}/bin:/opt/pgedge:${PATH}"
 RUN python3 -c "$(curl -fsSL ${PGEDGE_INSTALL_URL})" skipcache

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,21 @@ GIT_REVISION=$(shell git rev-parse --short HEAD)
 
 PGVS=15 16 17
 SPOCK_VERSION=4.0.10
-BUILD_REVISION=1
+BUILD_REVISION=2
 
-IMAGE_NAME=pgedge/pgedge
+IMAGE_NAME = pgedge/pgedge
 
-IMAGE_TAG = pg$(1)_$(SPOCK_VERSION)-$(BUILD_REVISION)
-IMAGE_TAG_LATEST = pg$(1)-latest
+OS ?= linux
+ARCH ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+PLATFORM ?= $(OS)/$(ARCH)
+PLATFORM_ARG ?= $(if $(PLATFORM),--platform=$(PLATFORM),)
 
-BUILDER_NAME=pgedge-builder
-
-DOCKER_BUILDX=docker buildx build --builder $(BUILDER_NAME) --platform linux/amd64,linux/arm64
+IMAGE_TAG ?= pg$(1)_$(SPOCK_VERSION)-$(BUILD_REVISION)
+IMAGE_TAG_LATEST ?= pg$(1)-latest
+IMAGE_TAG_LOCAL ?= pg$(1)-$(GIT_REVISION)-$(ARCH)
+BUILDER_NAME = pgedge-builder
+REPO ?= https://pgedge-download.s3.amazonaws.com/REPO
+DOCKER_BUILDX = docker buildx build --builder $(BUILDER_NAME) --platform linux/amd64,linux/arm64
 
 .PHONY: build
 build: $(foreach n,$(PGVS),build-pg$(n))
@@ -20,7 +25,7 @@ build: $(foreach n,$(PGVS),build-pg$(n))
 define BUILD_PGV
 .PHONY: build-pg$(1)
 build-pg$(1):
-	docker build --build-arg PGV=$(1) -t $(IMAGE_NAME):pg$(1)-$(GIT_REVISION) .
+	docker build $(PLATFORM_ARG) --build-arg PGV=$(1) --build-arg REPO=$(REPO) -t $(IMAGE_NAME):$(IMAGE_TAG_LOCAL) .
 endef
 
 $(foreach n,$(PGVS),$(eval $(call BUILD_PGV,$n)))
@@ -40,7 +45,7 @@ buildx: $(foreach n,$(PGVS),buildx-pg$(n))
 define BUILDX_PGV
 .PHONY: buildx-pg$(1)
 buildx-pg$(1):
-	$(DOCKER_BUILDX) --build-arg PGV=$(1) -t $(IMAGE_NAME):$(call IMAGE_TAG,$(1)) -t $(IMAGE_NAME):$(call IMAGE_TAG_LATEST,$(1)) --no-cache --push .
+	$(DOCKER_BUILDX) --build-arg PGV=$(1) --build-arg REPO=$(REPO) -t $(IMAGE_NAME):$(call IMAGE_TAG,$(1)) -t $(IMAGE_NAME):$(call IMAGE_TAG_LATEST,$(1)) --no-cache .
 endef
 
 $(foreach n,$(PGVS),$(eval $(call BUILDX_PGV,$n)))
@@ -51,7 +56,7 @@ test: $(foreach n,$(PGVS),test-pg$(n))
 define TEST_PGV
 .PHONY: test-pg$(1)
 test-pg$(1):
-	go run tests/main.go pgedge/pgedge:pg$(1)-$(GIT_REVISION) $(PWD)/tests/db.json
+	go run tests/main.go $(IMAGE_NAME):$(IMAGE_TAG_LOCAL) $(PWD)/tests/db.json
 endef
 
 $(foreach n,$(PGVS),$(eval $(call TEST_PGV,$n)))


### PR DESCRIPTION
This PR bumps the version to produce new images for the latest postgres minor releases available in the pgEdge repository:

-17.5
-16.9
-15.13

It also bumps a few dependencies (base image, psycopg) and improves the local build / test make targets for verifying image builds.