### PR TITLE
remove cli from image after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN useradd -u ${PGEDGE_USER_ID} -m pgedge -s /bin/bash && \
 # that we install the exact same version of ydiff as what's specified in the
 # CLI's requirements.txt.
 RUN su - pgedge -c "pip3 install --user psycopg[binary]==3.2.7 ydiff==1.3"
+# Remove pip
+RUN dnf remove -y python3-pip python-pip
 
 # Create the suggested data directory for Postgres in advance. Because Postgres
 # is picky about data directory ownership and permissions, the PGDATA directory
@@ -88,6 +90,9 @@ RUN ./pgedge/pgedge setup -U ${INIT_USERNAME} -d ${INIT_DATABASE} -P ${INIT_PASS
     && ./pgedge/pgedge um install postgis \
     && pg_ctl stop -t 60 --wait;
 
+RUN rm -rf /opt/pgedge/ctlibs \
+    && rm -rf /opt/pgedge/hub \
+    && rm -rf /opt/pgedge/pgedge
 USER pgedge
 
 # This is still required at runtime currently, but setting it earlier causes issues with dnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN useradd -u ${PGEDGE_USER_ID} -m pgedge -s /bin/bash && \
 # that we install the exact same version of ydiff as what's specified in the
 # CLI's requirements.txt.
 RUN su - pgedge -c "pip3 install --user psycopg[binary]==3.2.7 ydiff==1.3"
+
 # Remove pip
 RUN dnf remove -y python3-pip python-pip
 
@@ -84,9 +85,6 @@ ENV PATH="/opt/pgedge/pg${PGV}/bin:/opt/pgedge:${PATH}"
 RUN python3 -c "$(curl -fsSL ${PGEDGE_INSTALL_URL})" skipcache
 RUN ./pgedge/pgedge setup -U ${INIT_USERNAME} -d ${INIT_DATABASE} -P ${INIT_PASSWORD} --pg_ver ${PGV} --spock_ver ${SPOCK_VERSION} -p 5432 \
     && ./pgedge/pgedge um install vector \
-    && cp /lib64/libssh* /opt/pgedge/pg${PGV}/lib/ \
-    && cp /lib64/libpsl* /opt/pgedge/pg${PGV}/lib/ \
-    && cp /lib64/libbrotli* /opt/pgedge/pg${PGV}/lib/ \
     && ./pgedge/pgedge um install postgis \
     && pg_ctl stop -t 60 --wait;
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GIT_REVISION=$(shell git rev-parse --short HEAD)
 
 PGVS=15 16 17
 SPOCK_VERSION=4.0.10
-BUILD_REVISION=2
+BUILD_REVISION=3
 
 IMAGE_NAME = pgedge/pgedge
 

--- a/README.md
+++ b/README.md
@@ -157,3 +157,19 @@ default replication set by executing this command on all nodes:
 ```sql
 SELECT spock.repset_add_all_tables('default', ARRAY['public']);
 ```
+
+## Server Certificate and Private Key
+
+This image contains a default `server.crt` and `server.key` generated during the image build.
+
+When operating this image in your own environment, you should generate your own 
+`server.crt` and `server.key` using `openssl`. These files can then be mounted over top 
+of the default versions located at:
+
+ ```
+/opt/pgedge/data/pg17/server.key
+/opt/pgedge/data/pg17/server.crt
+ ```
+
+You can read more about certificate generation and using SSL connections with PostgreSQL 
+in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/ssl-tcp.html).


### PR DESCRIPTION
- remove cli from image after build (not needed, reduces size)
- remove temporary build workaround for postgis libs (added in https://github.com/pgEdge/pgedge-docker/pull/12)
- Add README section for overriding server certs
- bump build revision to 3